### PR TITLE
Fix torch.compile _tree_map recompilations

### DIFF
--- a/docs/compile-recompilation-investigation.md
+++ b/docs/compile-recompilation-investigation.md
@@ -111,9 +111,9 @@ The `is_compiling()` branch is still useful for eliminating `try/except` overhea
 
 The problem only arises when `pytree.tree_map` is called **inside** a Python function (`_tree_map`) that Dynamo compiles as its own frame. Then the guard is on `_tree_map`'s `func` parameter, not on `pytree.tree_map`'s.
 
-## Fix
+## Fix (implemented)
 
-Each method must call `pytree.tree_map` directly in compile mode, bypassing `_tree_map` entirely:
+Each method calls `pytree.tree_map` directly when `torch.compiler.is_compiling()` returns `True`, bypassing `_tree_map` entirely:
 
 ```python
 def abs(self) -> Self:
@@ -146,3 +146,62 @@ Recommended workarounds for users:
 **`mixins/shape_operations.py`** (5): `view`, `reshape`, `expand`, `permute`, `transpose`
 
 **`tensor_container.py`** (3): `__getitem__`, `_stack`, `_cat`
+
+## Verification
+
+### Integration test
+
+The fix was verified against the original failing command:
+
+```bash
+python scripts/benchmark_unsupervised.py \
+  +experiment/miniworld_maze=nine_rooms_episodic_large_goals \
+  +execution=local +preset=leg \
+  +preset/deployment/miniworld_maze=visual_small \
+  execution.compile=reduce-overhead
+```
+
+This previously raised `RecompileError` on `_tree_map`. After the fix, compilation
+succeeds and training proceeds. Note: `reduce-overhead` mode sets
+`torch._dynamo.config.error_on_recompile = True`, which makes any recompilation
+a hard error. Normal recompilations (e.g., Dynamo guarding on `requires_grad`
+for individual tensors) still occur, but these are standard Dynamo behavior — they
+only become errors if `error_on_recompile` is set.
+
+### Unit tests
+
+Tests are in `tests/test_compile_recompilation.py`.
+
+#### Testing challenge: Dynamo inlining
+
+The bug only manifests when Dynamo compiles `_tree_map` as a **separate frame**.
+In simple test functions with `fullgraph=True`, Dynamo inlines `_tree_map` into
+the caller's graph — eliminating the frame boundary and the callable-identity
+guard entirely. This means a naive test that compiles a function calling 12+
+TensorContainer methods will **pass even without the fix**.
+
+We confirmed this empirically: removing all `is_compiling()` fast paths and
+running the `fullgraph=True` tests still produced 0 failures.
+
+#### Test strategy
+
+Instead of trying to force Dynamo to create a separate frame (which depends on
+graph complexity, inlining budget, and PyTorch version), the tests verify the
+fix mechanism directly:
+
+1. **`test_methods_bypass_tree_map_when_compiling`**: Patches `_tree_map` with a
+   counting wrapper, compiles a function that calls 12 different methods, and
+   asserts `_tree_map` was called **0 times** during compiled execution. This
+   works because `torch.compiler.is_compiling()` returns `True` inside the
+   compiled region — methods with the fast path call `pytree.tree_map` directly.
+   **Without the fix, this test fails** (`_tree_map` is called 12 times).
+
+2. **`test_tree_map_directly_compiled_with_many_callables_hits_limit`**: Baseline
+   test confirming the underlying Dynamo behavior still exists. Directly compiles
+   `_tree_map` and calls it with 10 different lambdas — asserts
+   `FailOnRecompileLimitHit` is raised after 8. If a future PyTorch version
+   removes callable-identity guards, this test will fail, signaling the fast
+   paths are no longer needed (but remain harmless).
+
+3. **`test_compiled_output_matches_eager`**: Correctness test — verifies compiled
+   output matches eager output for all modified operations.

--- a/docs/compile-recompilation-investigation.md
+++ b/docs/compile-recompilation-investigation.md
@@ -63,22 +63,6 @@ However, in real-world workloads (e.g., a Dreamer model's `imagine()` function),
 - Dynamo's inlining budget being exhausted by the time it reaches `_tree_map`
 - Interaction with other compilation features (cudagraphs, device copies, etc.)
 
-### The `is_compiling()` fast path doesn't help
-
-We added an early return in `_tree_map` to skip the `try/except` error-wrapping in compile mode:
-
-```python
-@classmethod
-def _tree_map(cls, func, tree, *rests, is_leaf=None):
-    if torch.compiler.is_compiling():
-        return pytree.tree_map(func, tree, *rests, is_leaf=is_leaf)
-    # ... eager path with try/except error wrapping
-```
-
-This does **not** fix the recompilation issue because the `func.__code__` guard is evaluated **at the frame boundary** — before the function body executes. Dynamo decides whether to recompile `_tree_map` based on its arguments before entering it.
-
-The `is_compiling()` branch is still useful for eliminating `try/except` overhead (which can cause graph breaks on older PyTorch versions), but it doesn't prevent the callable-identity guard.
-
 ## Investigation Details
 
 ### What we tested
@@ -91,19 +75,60 @@ The `is_compiling()` branch is still useful for eliminating `try/except` overhea
 | `apply(fn)` from compiled wrapper with different `fn` values | Recompile per unique `fn` |
 | Real Dreamer model `imagine()` function (torch 2.8) | `RecompileError` on `_tree_map` |
 | Real Dreamer model `imagine()` function (torch 2.10) | `recompile_limit` hit on `_tree_map` |
+| `_tree_map_fn()` factory replacing per-method guards (real workload) | `recompile_limit` hit on per-method lambdas (rank mismatch) |
 
 ### Mechanisms explored to avoid callable guards
 
 | Mechanism | Applicable? | Notes |
 |---|---|---|
-| `torch.compiler.is_compiling()` fast path | No | Guard fires before function body |
+| `torch.compiler.is_compiling()` fast path in `_tree_map` | No | Guard fires before function body |
 | `torch.compiler.allow_in_graph` | No | Doesn't affect callable guards |
 | `torch.compiler.disable` on `_tree_map` | No | Causes graph breaks instead |
 | `torch._dynamo.config.recompile_limit` increase | Partial | Band-aid, doesn't fix root cause |
 | `guard_filter_fn` (drop `ID_MATCH` guards) | Unsafe | Silent incorrectness if wrong compiled code runs |
 | `set_stance(skip_guard_eval_unsafe=True)` | Unsafe | Skips all guard evaluation |
 | `torch._dynamo.nonstrict_trace` + `register_constant` | Experimental | Callable body not optimized by compiler |
-| Direct `pytree.tree_map` calls from each method | **Yes** | Eliminates the shared frame entirely |
+| `substitute_in_graph` on classmethod `_tree_map.__func__` | No | Classmethod descriptor identity mismatch; see below |
+| `substitute_in_graph` on module-level `_tree_map_impl` | No | Dynamo still compiles as its own frame in complex models; see below |
+| `_tree_map_fn()` classmethod factory | No | Moves the problem from `_tree_map` to per-method lambdas; see below |
+| Per-method `is_compiling()` guards calling `pytree.tree_map` directly | **Yes** | Eliminates the shared frame entirely |
+
+### Why `_tree_map_fn()` factory doesn't work
+
+We attempted to centralize the `is_compiling()` dispatch into a single classmethod factory:
+
+```python
+@classmethod
+def _tree_map_fn(cls):
+    if torch.compiler.is_compiling():
+        return pytree.tree_map
+    return cls._tree_map
+
+# Then each method becomes a single line:
+def abs(self) -> Self:
+    return self._tree_map_fn()(lambda x: x.abs(), self)
+
+def detach(self) -> Self:
+    return self._tree_map_fn()(lambda x: x.detach(), self)
+```
+
+This passes unit tests (where Dynamo inlines everything) but **fails in real-world workloads** with a different recompilation pattern. Instead of recompiling `_tree_map`, Dynamo now compiles each method's **lambda** as its own frame and recompiles it due to **tensor rank mismatches**:
+
+```
+[24/8] torch._dynamo hit config.recompile_limit (8)
+   function: '<lambda>' (tensorcontainer/tensor_container.py:892)
+   last reason: 24/7: tensor 'x' rank mismatch. expected 3, actual 2
+
+[17/8] torch._dynamo hit config.recompile_limit (8)
+   function: '<lambda>' (tensorcontainer/mixins/device_operations.py:86)
+   last reason: 17/7: tensor 'x' rank mismatch. expected 3, actual 2
+```
+
+**Why this happens**: With the factory pattern, `_tree_map_fn()` returns `pytree.tree_map` during compilation. `pytree.tree_map` is traced natively by Dynamo — it flattens the tree and applies the lambda to each leaf. But the lambda itself (`lambda x: x.detach()`) becomes its own compiled frame. When the same method (e.g., `detach()`) is called on TensorContainers with different structures (different numbers of tensors, or tensors with different ranks), Dynamo recompiles the lambda frame because the tensor rank guard fails.
+
+With the per-method `if is_compiling()` pattern, the lambda is written **inline in the method body** next to the `pytree.tree_map` call. Dynamo traces through `pytree.tree_map` natively (no frame boundary for it), and the lambda is inlined into the caller's graph as part of the tree-map trace. There's no separate frame for the lambda, so no rank-guard recompilation.
+
+**Key insight**: The factory pattern changes *where* the lambda is seen by Dynamo. With the factory, the lambda is passed as an argument to `pytree.tree_map` from a different scope, causing Dynamo to treat it as a separate frame. With the inline pattern, the lambda is part of the same trace context as the `pytree.tree_map` call, so it gets inlined into the graph.
 
 ### Why `pytree.tree_map` is special
 
@@ -111,7 +136,46 @@ The `is_compiling()` branch is still useful for eliminating `try/except` overhea
 
 The problem only arises when `pytree.tree_map` is called **inside** a Python function (`_tree_map`) that Dynamo compiles as its own frame. Then the guard is on `_tree_map`'s `func` parameter, not on `pytree.tree_map`'s.
 
+### Why `substitute_in_graph` doesn't work
+
+We explored two approaches with `substitute_in_graph`:
+
+#### Approach 1: On the classmethod's `__func__`
+
+```python
+@torch.compiler.substitute_in_graph(
+    TensorContainer._tree_map.__func__, skip_signature_check=True
+)
+def _tree_map_substitute(cls, func, tree, *rests, is_leaf=None):
+    return pytree.tree_map(func, tree, *rests, is_leaf=is_leaf)
+```
+
+This fails because `substitute_in_graph` registers the polyfill keyed on the function's `id()`. When Dynamo encounters `self._tree_map(...)`, it resolves through the classmethod descriptor — the resulting bound method has a different `id()` than `_tree_map.__func__`, so the polyfill lookup fails.
+
+#### Approach 2: On a module-level function
+
+To avoid the classmethod descriptor issue, we extracted the implementation into a module-level `_tree_map_impl` function with a stable `id()` and registered a polyfill on it:
+
+```python
+def _tree_map_impl(func, tree, *rests, is_leaf=None):
+    # ... error-wrapping implementation ...
+
+@torch.compiler.substitute_in_graph(_tree_map_impl)
+def _tree_map_compile(func, tree, *rests, is_leaf=None):
+    return pytree.tree_map(func, tree, *rests, is_leaf=is_leaf)
+```
+
+This passes unit tests (where Dynamo inlines `_tree_map_impl` into the caller's graph), but **still fails in real-world workloads**. The reason: `substitute_in_graph` operates at the **tracing** level — it tells Dynamo how to trace through a function when it encounters a call to it *within* a frame being traced. But when Dynamo decides to compile `_tree_map_impl` as its **own separate frame** (which happens in complex models), it's not tracing through a call — it's treating `_tree_map_impl` as a top-level compilation entry point. At that point, `substitute_in_graph` has no effect.
+
+**Key insight**: `substitute_in_graph` helps when a function is *inlined during tracing* of an outer frame. It does not help when a function is compiled as its own frame — which is exactly the scenario that causes the recompilation bug.
+
 ## Fix (implemented)
+
+### Two layers of defense
+
+The fix uses per-method `is_compiling()` guards as the primary defense, with a `substitute_in_graph` polyfill on the module-level `_tree_map_impl` as additional structural insurance:
+
+#### Layer 1: `is_compiling()` guards (proven fix)
 
 Each method calls `pytree.tree_map` directly when `torch.compiler.is_compiling()` returns `True`, bypassing `_tree_map` entirely:
 
@@ -125,6 +189,25 @@ def abs(self) -> Self:
 This ensures:
 - **Compile mode**: Each method is its own frame with a stable, fixed lambda. No shared `_tree_map` frame, no callable-identity guard churn.
 - **Eager mode**: `_tree_map` still provides rich error messages with keypath information and structure mismatch diagnostics.
+
+#### Layer 2: Module-level `_tree_map_impl` with polyfill (structural)
+
+The `_tree_map` classmethod delegates to a module-level `_tree_map_impl` function, which has a `substitute_in_graph` polyfill registered. In scenarios where Dynamo does inline `_tree_map_impl` (simple tests, future Dynamo improvements), the polyfill provides an additional optimization path:
+
+```python
+def _tree_map_impl(func, tree, *rests, is_leaf=None):
+    """Module-level function with stable identity for substitute_in_graph."""
+    # ... error-wrapping implementation ...
+
+@torch.compiler.substitute_in_graph(_tree_map_impl)
+def _tree_map_compile(func, tree, *rests, is_leaf=None):
+    return pytree.tree_map(func, tree, *rests, is_leaf=is_leaf)
+
+class TensorContainer:
+    @classmethod
+    def _tree_map(cls, func, tree, *rests, is_leaf=None):
+        return _tree_map_impl(func, tree, *rests, is_leaf=is_leaf)
+```
 
 ### `apply(fn)` — expected limitation
 
@@ -189,19 +272,23 @@ Instead of trying to force Dynamo to create a separate frame (which depends on
 graph complexity, inlining budget, and PyTorch version), the tests verify the
 fix mechanism directly:
 
-1. **`test_methods_bypass_tree_map_when_compiling`**: Patches `_tree_map` with a
+1. **`test_substitute_in_graph_registered`**: Verifies that `_tree_map_impl` has
+   a polyfill registered via `substitute_in_graph`, confirming the structural
+   defense is in place.
+
+2. **`test_methods_bypass_tree_map_when_compiling`**: Patches `_tree_map` with a
    counting wrapper, compiles a function that calls 12 different methods, and
    asserts `_tree_map` was called **0 times** during compiled execution. This
    works because `torch.compiler.is_compiling()` returns `True` inside the
    compiled region — methods with the fast path call `pytree.tree_map` directly.
    **Without the fix, this test fails** (`_tree_map` is called 12 times).
 
-2. **`test_tree_map_directly_compiled_with_many_callables_hits_limit`**: Baseline
+3. **`test_tree_map_directly_compiled_with_many_callables_hits_limit`**: Baseline
    test confirming the underlying Dynamo behavior still exists. Directly compiles
-   `_tree_map` and calls it with 10 different lambdas — asserts
+   `_tree_map_impl` and calls it with 10 different lambdas — asserts
    `FailOnRecompileLimitHit` is raised after 8. If a future PyTorch version
    removes callable-identity guards, this test will fail, signaling the fast
    paths are no longer needed (but remain harmless).
 
-3. **`test_compiled_output_matches_eager`**: Correctness test — verifies compiled
+4. **`test_compiled_output_matches_eager`**: Correctness test — verifies compiled
    output matches eager output for all modified operations.

--- a/docs/compile-recompilation-investigation.md
+++ b/docs/compile-recompilation-investigation.md
@@ -1,0 +1,148 @@
+# `_tree_map` Recompilation Under `torch.compile`
+
+## Problem
+
+When using TensorContainer inside a `torch.compile` region, users hit `RecompileError` or exhaust the recompile limit:
+
+```
+torch._dynamo.exc.RecompileError: Recompiling function _tree_map
+    triggered by the following guard failure(s):
+    - 4/0: ___check_obj_id(func.__code__, 126633386583440)
+```
+
+This occurs on both PyTorch 2.8 and 2.10 in real-world workloads.
+
+## Root Cause
+
+### How `_tree_map` works
+
+Every tensor operation in TensorContainer (`abs()`, `view()`, `float()`, `detach()`, `__getitem__`, etc.) routes through a single shared classmethod `_tree_map`:
+
+```python
+# In abs():
+return self._tree_map(lambda x: x.abs(), self)
+
+# In float():
+return self._tree_map(lambda x: x.float(), self)
+
+# In __getitem__():
+return self._tree_map(lambda x: x[key], self)
+```
+
+There are ~26 call sites across 6 files, each passing a **different lambda** to `_tree_map`.
+
+### Why Dynamo recompiles
+
+Dynamo treats `_tree_map` as its own compiled frame (not inlined into the caller). When a compiled function calls multiple TensorContainer methods, each method passes a different lambda through `_tree_map`. Dynamo guards on `func.__code__` at the `_tree_map` frame boundary:
+
+1. `td.detach()` → `_tree_map(lambda x: x.detach(), self)` → **compile frame 1**
+2. `td.view(20)` → `_tree_map(lambda x: x.view(20, ...), self)` → **recompile** (different `func.__code__`)
+3. `td.float()` → `_tree_map(lambda x: x.float(), self)` → **recompile** (different `func.__code__`)
+4. ... and so on until the recompile limit (default 8) is exhausted
+
+Each unique lambda has a different `__code__` object, triggering a new recompilation of the `_tree_map` frame.
+
+### Why `_tree_map` is a separate frame
+
+We initially expected Dynamo to **inline** `_tree_map` into the calling function (eliminating the frame boundary). This does happen in isolated test scenarios on PyTorch 2.10:
+
+```python
+# This works: 1 frame, 0 recompilations on torch 2.10
+@torch.compile
+def step(td):
+    a = td.abs()
+    b = td.float()
+    c = td.view(12)
+    return a, b, c
+```
+
+However, in real-world workloads (e.g., a Dreamer model's `imagine()` function), `_tree_map` is **not inlined** — even on torch 2.10. The multi-frame compilation context `[4/8]` in the warning confirms `_tree_map` is compiled as its own frame. The exact reason Dynamo doesn't inline in these cases may relate to:
+
+- The complexity/depth of the calling function
+- Classmethod dispatch overhead
+- Dynamo's inlining budget being exhausted by the time it reaches `_tree_map`
+- Interaction with other compilation features (cudagraphs, device copies, etc.)
+
+### The `is_compiling()` fast path doesn't help
+
+We added an early return in `_tree_map` to skip the `try/except` error-wrapping in compile mode:
+
+```python
+@classmethod
+def _tree_map(cls, func, tree, *rests, is_leaf=None):
+    if torch.compiler.is_compiling():
+        return pytree.tree_map(func, tree, *rests, is_leaf=is_leaf)
+    # ... eager path with try/except error wrapping
+```
+
+This does **not** fix the recompilation issue because the `func.__code__` guard is evaluated **at the frame boundary** — before the function body executes. Dynamo decides whether to recompile `_tree_map` based on its arguments before entering it.
+
+The `is_compiling()` branch is still useful for eliminating `try/except` overhead (which can cause graph breaks on older PyTorch versions), but it doesn't prevent the callable-identity guard.
+
+## Investigation Details
+
+### What we tested
+
+| Scenario | Result |
+|---|---|
+| Simple test: 10 ops in one compiled function (torch 2.10, isolated) | 1 frame, 0 recompiles |
+| 10 levels of TensorDict nesting with `.view()` (torch 2.10, isolated) | 1 frame, 0 recompiles |
+| Directly compiling `_tree_map` with 10 different callables | `FailOnRecompileLimitHit` after 8 |
+| `apply(fn)` from compiled wrapper with different `fn` values | Recompile per unique `fn` |
+| Real Dreamer model `imagine()` function (torch 2.8) | `RecompileError` on `_tree_map` |
+| Real Dreamer model `imagine()` function (torch 2.10) | `recompile_limit` hit on `_tree_map` |
+
+### Mechanisms explored to avoid callable guards
+
+| Mechanism | Applicable? | Notes |
+|---|---|---|
+| `torch.compiler.is_compiling()` fast path | No | Guard fires before function body |
+| `torch.compiler.allow_in_graph` | No | Doesn't affect callable guards |
+| `torch.compiler.disable` on `_tree_map` | No | Causes graph breaks instead |
+| `torch._dynamo.config.recompile_limit` increase | Partial | Band-aid, doesn't fix root cause |
+| `guard_filter_fn` (drop `ID_MATCH` guards) | Unsafe | Silent incorrectness if wrong compiled code runs |
+| `set_stance(skip_guard_eval_unsafe=True)` | Unsafe | Skips all guard evaluation |
+| `torch._dynamo.nonstrict_trace` + `register_constant` | Experimental | Callable body not optimized by compiler |
+| Direct `pytree.tree_map` calls from each method | **Yes** | Eliminates the shared frame entirely |
+
+### Why `pytree.tree_map` is special
+
+`pytree.tree_map` is handled natively by Dynamo — it's **traced through**, not compiled as a Python frame. When a method calls `pytree.tree_map(fn, self)` directly, Dynamo traces the tree flattening, applies `fn` to each leaf symbolically, and generates the graph. There's no frame boundary and no guard on `fn` at a frame level.
+
+The problem only arises when `pytree.tree_map` is called **inside** a Python function (`_tree_map`) that Dynamo compiles as its own frame. Then the guard is on `_tree_map`'s `func` parameter, not on `pytree.tree_map`'s.
+
+## Fix
+
+Each method must call `pytree.tree_map` directly in compile mode, bypassing `_tree_map` entirely:
+
+```python
+def abs(self) -> Self:
+    if torch.compiler.is_compiling():
+        return pytree.tree_map(lambda x: x.abs(), self)
+    return self._tree_map(lambda x: x.abs(), self)
+```
+
+This ensures:
+- **Compile mode**: Each method is its own frame with a stable, fixed lambda. No shared `_tree_map` frame, no callable-identity guard churn.
+- **Eager mode**: `_tree_map` still provides rich error messages with keypath information and structure mismatch diagnostics.
+
+### `apply(fn)` — expected limitation
+
+`apply(fn)` passes a user-provided callable. If a compiled function calls `apply()` with different `fn` values across invocations, Dynamo **must** recompile because different callables produce different computation graphs. This is fundamental Dynamo behavior, not a TensorContainer bug.
+
+Recommended workarounds for users:
+- Use built-in methods (`abs`, `float`, `view`, etc.) instead of `apply()` when possible
+- Call `apply()` outside the compiled region
+- Increase `recompile_limit` / `cache_size_limit` if many unique callables are expected
+
+### Affected call sites (26 total)
+
+**`mixins/math_operations.py`** (10): `abs`, `add`, `sub`, `mul`, `div`, `pow`, `sqrt`, `log`, `neg`, `clamp`
+
+**`mixins/type_operations.py`** (5): `float`, `double`, `half`, `long`, `int`
+
+**`mixins/device_operations.py`** (3): `detach`, `clone`, `copy`
+
+**`mixins/shape_operations.py`** (5): `view`, `reshape`, `expand`, `permute`, `transpose`
+
+**`tensor_container.py`** (3): `__getitem__`, `_stack`, `_cat`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tensorcontainer"
-version = "0.8.3"
+version = "0.9.0"
+author = "Tim Joseph
 description = "TensorDict-like functionality for PyTorch with PyTree compatibility and torch.compile support"
 authors = [{name="Tim Joseph", email="tim@mctigger.com"}]
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tensorcontainer"
 version = "0.9.0"
-author = "Tim Joseph
 description = "TensorDict-like functionality for PyTorch with PyTree compatibility and torch.compile support"
 authors = [{name="Tim Joseph", email="tim@mctigger.com"}]
 license = {text = "MIT"}

--- a/src/tensorcontainer/mixins/device_operations.py
+++ b/src/tensorcontainer/mixins/device_operations.py
@@ -83,6 +83,8 @@ class TensorDeviceOperationsMixin(TensorContainerProtocol):
             >>> detached = container.detach()
             >>> # detached['a'].requires_grad == False
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.detach(), self)
         return self._tree_map(lambda x: x.detach(), self)
 
     def clone(self, *, memory_format: torch.memory_format | None = None) -> Self:
@@ -108,6 +110,8 @@ class TensorDeviceOperationsMixin(TensorContainerProtocol):
             >>> # Clone preserves independence
             >>> cloned[0] = new_data  # Original container unchanged
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.clone(memory_format=memory_format), self)
         cloned_td = self._tree_map(lambda x: x.clone(memory_format=memory_format), self)
         return cloned_td
 
@@ -126,6 +130,8 @@ class TensorDeviceOperationsMixin(TensorContainerProtocol):
             >>> # copied and container share the same tensor data
             >>> # but have independent container structures
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x, self)
         return self._tree_map(lambda x: x, self)
 
     def cpu(self) -> Self:

--- a/src/tensorcontainer/mixins/math_operations.py
+++ b/src/tensorcontainer/mixins/math_operations.py
@@ -6,6 +6,8 @@ tensors in the container.
 
 from __future__ import annotations
 
+import torch
+import torch.utils._pytree as pytree
 from typing_extensions import Self
 
 from tensorcontainer.protocols import TensorContainerProtocol
@@ -40,6 +42,8 @@ class TensorMathOperationsMixin(TensorContainerProtocol):
             >>> abs_container = container.abs()
             >>> # abs_container['a'] == tensor([1, 2, 3])
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.abs(), self)
         return self._tree_map(lambda x: x.abs(), self)
 
     def add(self, other) -> Self:
@@ -56,6 +60,8 @@ class TensorMathOperationsMixin(TensorContainerProtocol):
             >>> result = container.add(10)
             >>> # result['a'] == tensor([11, 12, 13])
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.add(other), self)
         return self._tree_map(lambda x: x.add(other), self)
 
     def sub(self, other) -> Self:
@@ -72,6 +78,8 @@ class TensorMathOperationsMixin(TensorContainerProtocol):
             >>> result = container.sub(5)
             >>> # result['a'] == tensor([5, 15, 25])
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.sub(other), self)
         return self._tree_map(lambda x: x.sub(other), self)
 
     def mul(self, other) -> Self:
@@ -88,6 +96,8 @@ class TensorMathOperationsMixin(TensorContainerProtocol):
             >>> result = container.mul(2)
             >>> # result['a'] == tensor([2, 4, 6])
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.mul(other), self)
         return self._tree_map(lambda x: x.mul(other), self)
 
     def div(self, other) -> Self:
@@ -104,6 +114,8 @@ class TensorMathOperationsMixin(TensorContainerProtocol):
             >>> result = container.div(2)
             >>> # result['a'] == tensor([5, 10, 15])
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.div(other), self)
         return self._tree_map(lambda x: x.div(other), self)
 
     def pow(self, exponent) -> Self:
@@ -120,6 +132,8 @@ class TensorMathOperationsMixin(TensorContainerProtocol):
             >>> result = container.pow(2)
             >>> # result['a'] == tensor([4, 9, 16])
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.pow(exponent), self)
         return self._tree_map(lambda x: x.pow(exponent), self)
 
     def sqrt(self) -> Self:
@@ -133,6 +147,8 @@ class TensorMathOperationsMixin(TensorContainerProtocol):
             >>> result = container.sqrt()
             >>> # result['a'] == tensor([2, 3, 4])
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.sqrt(), self)
         return self._tree_map(lambda x: x.sqrt(), self)
 
     def log(self) -> Self:
@@ -146,6 +162,8 @@ class TensorMathOperationsMixin(TensorContainerProtocol):
             >>> result = container.log()
             >>> # result['a'] == tensor([0, 0.693, 1.099])
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.log(), self)
         return self._tree_map(lambda x: x.log(), self)
 
     def neg(self) -> Self:
@@ -159,6 +177,8 @@ class TensorMathOperationsMixin(TensorContainerProtocol):
             >>> result = container.neg()
             >>> # result['a'] == tensor([-1, 2, -3])
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.neg(), self)
         return self._tree_map(lambda x: x.neg(), self)
 
     def clamp(self, min, max) -> Self:
@@ -176,4 +196,6 @@ class TensorMathOperationsMixin(TensorContainerProtocol):
             >>> result = container.clamp(2, 8)
             >>> # result['a'] == tensor([2, 5, 8])
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.clamp(min, max), self)
         return self._tree_map(lambda x: x.clamp(min, max), self)

--- a/src/tensorcontainer/mixins/shape_operations.py
+++ b/src/tensorcontainer/mixins/shape_operations.py
@@ -7,6 +7,7 @@ of tensor containers while preserving event dimensions.
 from __future__ import annotations
 
 import torch
+import torch.utils._pytree as pytree
 from typing_extensions import Self
 
 from tensorcontainer.protocols import TensorContainerProtocol
@@ -54,6 +55,8 @@ class TensorShapeOperationsMixin(TensorContainerProtocol):
             >>> # Original: tensor.shape == (4, 3, 128)  # event dims (128,)
             >>> # After view(2, 6): tensor.shape == (2, 6, 128)
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.view(*shape, *x.shape[self.ndim :]), self)
         return self._tree_map(lambda x: x.view(*shape, *x.shape[self.ndim :]), self)
 
     def reshape(self, *shape: int) -> Self:
@@ -78,6 +81,8 @@ class TensorShapeOperationsMixin(TensorContainerProtocol):
             >>> transposed = container.transpose(0, 1)  # Non-contiguous
             >>> reshaped = transposed.reshape(6, 2)     # Works (reshape can copy)
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.reshape(*shape, *x.shape[self.ndim :]), self)
         return self._tree_map(lambda x: x.reshape(*shape, *x.shape[self.ndim :]), self)
 
     def expand(self, *shape: int) -> Self:
@@ -92,6 +97,8 @@ class TensorShapeOperationsMixin(TensorContainerProtocol):
         Returns:
             TensorContainer: Container with expanded batch dimensions
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.expand(*shape, *x.shape[self.ndim :]), self)
         return self._tree_map(lambda x: x.expand(*shape, *x.shape[self.ndim :]), self)
 
     def permute(self, *dims: int) -> Self:
@@ -117,6 +124,10 @@ class TensorShapeOperationsMixin(TensorContainerProtocol):
                 raise RuntimeError(
                     f"permute(): dimension out of range (expected to be in range of [0, {self.ndim - 1}], but got {dim})"
                 )
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(
+                lambda x: x.permute(*dims, *range(self.ndim, x.ndim)), self
+            )
         return self._tree_map(
             lambda x: x.permute(*dims, *range(self.ndim, x.ndim)), self
         )
@@ -168,6 +179,8 @@ class TensorShapeOperationsMixin(TensorContainerProtocol):
         Returns:
             A new container with the specified dimensions transposed.
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.transpose(dim0, dim1), self)
         return self._tree_map(lambda x: x.transpose(dim0, dim1), self)
 
     def unsqueeze(self, dim: int) -> Self:

--- a/src/tensorcontainer/mixins/shape_operations.py
+++ b/src/tensorcontainer/mixins/shape_operations.py
@@ -56,7 +56,9 @@ class TensorShapeOperationsMixin(TensorContainerProtocol):
             >>> # After view(2, 6): tensor.shape == (2, 6, 128)
         """
         if torch.compiler.is_compiling():
-            return pytree.tree_map(lambda x: x.view(*shape, *x.shape[self.ndim :]), self)
+            return pytree.tree_map(
+                lambda x: x.view(*shape, *x.shape[self.ndim :]), self
+            )
         return self._tree_map(lambda x: x.view(*shape, *x.shape[self.ndim :]), self)
 
     def reshape(self, *shape: int) -> Self:
@@ -82,7 +84,9 @@ class TensorShapeOperationsMixin(TensorContainerProtocol):
             >>> reshaped = transposed.reshape(6, 2)     # Works (reshape can copy)
         """
         if torch.compiler.is_compiling():
-            return pytree.tree_map(lambda x: x.reshape(*shape, *x.shape[self.ndim :]), self)
+            return pytree.tree_map(
+                lambda x: x.reshape(*shape, *x.shape[self.ndim :]), self
+            )
         return self._tree_map(lambda x: x.reshape(*shape, *x.shape[self.ndim :]), self)
 
     def expand(self, *shape: int) -> Self:
@@ -98,7 +102,9 @@ class TensorShapeOperationsMixin(TensorContainerProtocol):
             TensorContainer: Container with expanded batch dimensions
         """
         if torch.compiler.is_compiling():
-            return pytree.tree_map(lambda x: x.expand(*shape, *x.shape[self.ndim :]), self)
+            return pytree.tree_map(
+                lambda x: x.expand(*shape, *x.shape[self.ndim :]), self
+            )
         return self._tree_map(lambda x: x.expand(*shape, *x.shape[self.ndim :]), self)
 
     def permute(self, *dims: int) -> Self:

--- a/src/tensorcontainer/mixins/type_operations.py
+++ b/src/tensorcontainer/mixins/type_operations.py
@@ -6,6 +6,8 @@ to different data types.
 
 from __future__ import annotations
 
+import torch
+import torch.utils._pytree as pytree
 from typing_extensions import Self
 
 from tensorcontainer.protocols import TensorContainerProtocol
@@ -39,6 +41,8 @@ class TensorTypeOperationsMixin(TensorContainerProtocol):
             >>> float_container = container.float()
             >>> # float_container['a'].dtype == torch.float32
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.float(), self)
         return self._tree_map(lambda x: x.float(), self)
 
     def double(self) -> Self:
@@ -52,6 +56,8 @@ class TensorTypeOperationsMixin(TensorContainerProtocol):
             >>> double_container = container.double()
             >>> # double_container['a'].dtype == torch.float64
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.double(), self)
         return self._tree_map(lambda x: x.double(), self)
 
     def half(self) -> Self:
@@ -65,6 +71,8 @@ class TensorTypeOperationsMixin(TensorContainerProtocol):
             >>> half_container = container.half()
             >>> # half_container['a'].dtype == torch.float16
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.half(), self)
         return self._tree_map(lambda x: x.half(), self)
 
     def long(self) -> Self:
@@ -78,6 +86,8 @@ class TensorTypeOperationsMixin(TensorContainerProtocol):
             >>> long_container = container.long()
             >>> # long_container['a'].dtype == torch.int64
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.long(), self)
         return self._tree_map(lambda x: x.long(), self)
 
     def int(self) -> Self:
@@ -92,4 +102,6 @@ class TensorTypeOperationsMixin(TensorContainerProtocol):
             >>> # int_container['a'].dtype == torch.int32
             >>> # int_container['a'] == tensor([1, 2, 3])
         """
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x.int(), self)
         return self._tree_map(lambda x: x.int(), self)

--- a/src/tensorcontainer/tensor_container.py
+++ b/src/tensorcontainer/tensor_container.py
@@ -434,8 +434,6 @@ class TensorContainer(TensorContainerProtocol):
 
         # When compiling, skip error-wrapping overhead — try/except and
         # tree_map_with_path add complexity that dynamo doesn't need.
-        if torch.compiler.is_compiling():
-            return pytree.tree_map(func, tree, *rests, is_leaf=is_leaf)
 
         def func_with_error_path(keypath, x, *xs):
             """
@@ -879,6 +877,8 @@ class TensorContainer(TensorContainerProtocol):
             key = (key,)
         key = self.transform_ellipsis_index(self.shape, key)
 
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(lambda x: x[key], self)
         return self._tree_map(lambda x: x[key], self)
 
     def __setitem__(self: Self, index: IndexType, value: Self) -> None:
@@ -939,6 +939,8 @@ def _stack(
         )
 
     # Pytree handles the stacking of individual tensors and metadata consistency
+    if torch.compiler.is_compiling():
+        return pytree.tree_map(lambda *x: torch.stack(x, dim), *tensors)
     result_td = TensorContainer._tree_map(lambda *x: torch.stack(x, dim), *tensors)
 
     return result_td
@@ -964,6 +966,8 @@ def _cat(
 
     # Create a new TensorContainer of the same type as the first one
     # and apply torch.cat to its internal tensors
+    if torch.compiler.is_compiling():
+        return pytree.tree_map(lambda *x: torch.cat(x, dim), *tensors)
     result_td = TensorContainer._tree_map(lambda *x: torch.cat(x, dim), *tensors)
 
     return result_td

--- a/src/tensorcontainer/tensor_container.py
+++ b/src/tensorcontainer/tensor_container.py
@@ -432,6 +432,11 @@ class TensorContainer(TensorContainerProtocol):
             that internally use `_tree_map` to provide their functionality.
         """
 
+        # When compiling, skip error-wrapping overhead — try/except and
+        # tree_map_with_path add complexity that dynamo doesn't need.
+        if torch.compiler.is_compiling():
+            return pytree.tree_map(func, tree, *rests, is_leaf=is_leaf)
+
         def func_with_error_path(keypath, x, *xs):
             """
             This function wraps the given func just to provide error messages

--- a/test_frame_guards.py
+++ b/test_frame_guards.py
@@ -24,7 +24,9 @@ def run(name, fn):
     td = _get_td()
     try:
         with torch._dynamo.config.patch(
-            recompile_limit=0, cache_size_limit=64, fail_on_recompile_limit_hit=True,
+            recompile_limit=0,
+            cache_size_limit=64,
+            fail_on_recompile_limit_hit=True,
         ):
             fn(td)
             fn(td)
@@ -39,13 +41,22 @@ def run_direct(name, map_fn):
     td = _get_td()
     compiled = torch.compile(map_fn, fullgraph=True)
     fns = [
-        lambda x: x.abs(), lambda x: x.neg(), lambda x: x.float(),
-        lambda x: x.double(), lambda x: x.clone(), lambda x: x.detach(),
-        lambda x: x.sqrt(), lambda x: x.half(), lambda x: x.long(), lambda x: x.int(),
+        lambda x: x.abs(),
+        lambda x: x.neg(),
+        lambda x: x.float(),
+        lambda x: x.double(),
+        lambda x: x.clone(),
+        lambda x: x.detach(),
+        lambda x: x.sqrt(),
+        lambda x: x.half(),
+        lambda x: x.long(),
+        lambda x: x.int(),
     ]
     try:
         with torch._dynamo.config.patch(
-            recompile_limit=8, cache_size_limit=8, fail_on_recompile_limit_hit=True,
+            recompile_limit=8,
+            cache_size_limit=8,
+            fail_on_recompile_limit_hit=True,
         ):
             for f in fns:
                 compiled(f, td)

--- a/test_frame_guards.py
+++ b/test_frame_guards.py
@@ -1,0 +1,110 @@
+"""Definitive test: when does _map help vs _tree_map?
+
+Three scenarios:
+1. Compiled directly as entry point: torch.compile(fn)(different_callables...)
+2. Called inside a compiled function with baked-in lambdas
+3. Methods called inside a compiled function
+"""
+
+import torch
+import torch._dynamo
+
+from tensorcontainer.tensor_container import TensorContainer, _map
+from tensorcontainer.tensor_dict import TensorDict
+
+keys = ["a", "b", "c", "d", "e", "f", "g"]
+
+
+def _get_td():
+    return TensorDict({k: torch.randn(3, 4, 5) for k in keys}, shape=(3, 4))
+
+
+def run(name, fn):
+    torch._dynamo.reset()
+    td = _get_td()
+    try:
+        with torch._dynamo.config.patch(
+            recompile_limit=0, cache_size_limit=64, fail_on_recompile_limit_hit=True,
+        ):
+            fn(td)
+            fn(td)
+        print(f"  PASS  {name}")
+    except torch._dynamo.exc.FailOnRecompileLimitHit:
+        print(f"  FAIL  {name}")
+
+
+# === Scenario 1: compiled directly, called with different callables ===
+def run_direct(name, map_fn):
+    torch._dynamo.reset()
+    td = _get_td()
+    compiled = torch.compile(map_fn, fullgraph=True)
+    fns = [
+        lambda x: x.abs(), lambda x: x.neg(), lambda x: x.float(),
+        lambda x: x.double(), lambda x: x.clone(), lambda x: x.detach(),
+        lambda x: x.sqrt(), lambda x: x.half(), lambda x: x.long(), lambda x: x.int(),
+    ]
+    try:
+        with torch._dynamo.config.patch(
+            recompile_limit=8, cache_size_limit=8, fail_on_recompile_limit_hit=True,
+        ):
+            for f in fns:
+                compiled(f, td)
+        print(f"  PASS  {name}")
+    except torch._dynamo.exc.FailOnRecompileLimitHit:
+        print(f"  FAIL  {name}")
+
+
+# === Scenario 2: baked-in lambdas inside compiled function ===
+def baked_tree_map(td):
+    TensorContainer._tree_map(lambda x: x.abs(), td)
+    TensorContainer._tree_map(lambda x: x.neg(), td)
+    TensorContainer._tree_map(lambda x: x.float(), td)
+    TensorContainer._tree_map(lambda x: x.double(), td)
+    TensorContainer._tree_map(lambda x: x.clone(), td)
+    TensorContainer._tree_map(lambda x: x.detach(), td)
+    TensorContainer._tree_map(lambda x: x.sqrt(), td)
+    TensorContainer._tree_map(lambda x: x.half(), td)
+    TensorContainer._tree_map(lambda x: x.long(), td)
+    return TensorContainer._tree_map(lambda x: x.int(), td)
+
+
+def baked_map(td):
+    _map(lambda x: x.abs(), td)
+    _map(lambda x: x.neg(), td)
+    _map(lambda x: x.float(), td)
+    _map(lambda x: x.double(), td)
+    _map(lambda x: x.clone(), td)
+    _map(lambda x: x.detach(), td)
+    _map(lambda x: x.sqrt(), td)
+    _map(lambda x: x.half(), td)
+    _map(lambda x: x.long(), td)
+    return _map(lambda x: x.int(), td)
+
+
+# === Scenario 3: methods ===
+def via_methods(td):
+    td.abs()
+    td.neg()
+    td.float()
+    td.double()
+    td.clone()
+    td.detach()
+    td.sqrt()
+    td.half()
+    td.long()
+    return td.int()
+
+
+print()
+print("Scenario 1: compiled DIRECTLY, called with different callables each time")
+run_direct("_tree_map", TensorContainer._tree_map)
+run_direct("_map", _map)
+
+print()
+print("Scenario 2: baked-in lambdas inside one compiled function")
+run("_tree_map with baked-in lambdas", torch.compile(baked_tree_map, fullgraph=True))
+run("_map with baked-in lambdas", torch.compile(baked_map, fullgraph=True))
+
+print()
+print("Scenario 3: TensorDict methods inside one compiled function")
+run("methods (currently use _map)", torch.compile(via_methods, fullgraph=True))

--- a/tests/tensor_dict/test_compile_tree_map.py
+++ b/tests/tensor_dict/test_compile_tree_map.py
@@ -33,6 +33,7 @@ def _get_td():
 
 # --- Named callables for fan-out tests ---
 
+
 def _clone_leaf(x):
     return x.clone()
 
@@ -206,8 +207,16 @@ class TestDynamicCallableFanOut:
         compiled_tree_map = torch.compile(TensorDict._tree_map, fullgraph=True)
 
         all_fns = [
-            _clone_leaf, _detach_leaf, _float_leaf, _double_leaf, _half_leaf,
-            _long_leaf, _int_leaf, _abs_leaf, _neg_leaf, _sqrt_leaf,
+            _clone_leaf,
+            _detach_leaf,
+            _float_leaf,
+            _double_leaf,
+            _half_leaf,
+            _long_leaf,
+            _int_leaf,
+            _abs_leaf,
+            _neg_leaf,
+            _sqrt_leaf,
         ]
 
         with torch._dynamo.config.patch(

--- a/tests/tensor_dict/test_compile_tree_map.py
+++ b/tests/tensor_dict/test_compile_tree_map.py
@@ -1,0 +1,259 @@
+"""Tests for _tree_map behavior under torch.compile.
+
+There are two distinct concerns:
+
+1. **Internal operation fan-out**: Methods like abs(), float(), neg() each pass
+   a different lambda through _tree_map. When these are called within a single
+   compiled function, Dynamo inlines them into one graph — no recompilation.
+
+2. **Dynamic callable fan-out**: When _tree_map or apply() is the compiled entry
+   point and called repeatedly with different callables, Dynamo guards on callable
+   identity and recompiles each time. This is expected Dynamo behavior, not a
+   TensorContainer bug.
+"""
+
+import pytest
+import torch
+import torch._dynamo
+from torch._dynamo.testing import CompileCounter
+
+from tensorcontainer.tensor_dict import TensorDict
+from tests.compile_utils import run_and_count_graph_breaks
+from tests.conftest import skipif_no_compile
+
+keys = ["a", "b", "c", "d", "e", "f", "g"]
+
+
+def _get_td():
+    return TensorDict(
+        {k: torch.randn(3, 4, 5) for k in keys},
+        shape=(3, 4),
+    )
+
+
+# --- Named callables for fan-out tests ---
+
+def _clone_leaf(x):
+    return x.clone()
+
+
+def _detach_leaf(x):
+    return x.detach()
+
+
+def _float_leaf(x):
+    return x.float()
+
+
+def _double_leaf(x):
+    return x.double()
+
+
+def _half_leaf(x):
+    return x.half()
+
+
+def _long_leaf(x):
+    return x.long()
+
+
+def _int_leaf(x):
+    return x.int()
+
+
+def _abs_leaf(x):
+    return x.abs()
+
+
+def _neg_leaf(x):
+    return x.neg()
+
+
+def _sqrt_leaf(x):
+    return x.sqrt()
+
+
+@skipif_no_compile
+class TestInternalOpFanOut:
+    """Tests that many different internal ops in one compiled function work without
+    graph breaks or recompilation issues.
+
+    This is the common usage pattern: the user compiles their function which
+    internally calls multiple TensorContainer methods. Dynamo inlines through
+    each method and sees each lambda exactly once — no recompilation.
+    """
+
+    def test_many_ops_single_compiled_function_no_graph_break(self):
+        """Many different _tree_map-based operations in one function produce
+        zero graph breaks."""
+        td = _get_td()
+
+        def many_ops(td):
+            a = td.abs()
+            b = td.float()
+            c = td.neg()
+            d = td.sqrt()
+            e = td.clone()
+            f = td.detach()
+            g = td[0]
+            h = td.double()
+            i = td.half()
+            j = td.long()
+            return a, b, c, d, e, f, g, h, i, j
+
+        run_and_count_graph_breaks(many_ops, td, expected_graph_breaks=0)
+
+    def test_many_ops_no_recompilation(self):
+        """Calling a compiled function with many ops repeatedly doesn't recompile."""
+        td = _get_td()
+
+        def many_ops(td):
+            a = td.abs()
+            b = td.float()
+            c = td.neg()
+            d = td.sqrt()
+            e = td.clone()
+            f = td.detach()
+            g = td[0]
+            h = td.double()
+            i = td.half()
+            j = td.long()
+            return a, b, c, d, e, f, g, h, i, j
+
+        torch._dynamo.reset()
+        counter = CompileCounter()
+        compiled = torch.compile(many_ops, backend=counter, fullgraph=True)
+
+        with torch._dynamo.config.patch(
+            recompile_limit=8,
+            cache_size_limit=8,
+            fail_on_recompile_limit_hit=True,
+        ):
+            compiled(td)
+            compiled(_get_td())  # second call with same-shaped input
+
+        assert counter.frame_count == 1
+
+    def test_apply_in_compiled_function_no_graph_break(self):
+        """apply() with a lambda inside a compiled function produces no graph breaks."""
+        td = _get_td()
+
+        def fn(td):
+            return td.apply(lambda x: x * 2)
+
+        run_and_count_graph_breaks(fn, td, expected_graph_breaks=0)
+
+
+@skipif_no_compile
+class TestDynamicCallableFanOut:
+    """Tests documenting expected Dynamo behavior when _tree_map/apply is called
+    with different callables across separate compiled invocations.
+
+    Dynamo guards on callable identity (func.__code__). When a compiled function
+    receives a different callable, it must recompile because the callable determines
+    the computation graph. This is fundamental Dynamo behavior, not a TensorContainer
+    issue.
+    """
+
+    def test_tree_map_recompiles_with_different_callables(self):
+        """Directly compiling _tree_map and calling with different callables
+        causes recompilation — one per unique callable."""
+        torch._dynamo.reset()
+        td = _get_td()
+
+        counter = CompileCounter()
+        compiled_tree_map = torch.compile(
+            TensorDict._tree_map, backend=counter, fullgraph=True
+        )
+
+        compiled_tree_map(_clone_leaf, td)
+        compiled_tree_map(_detach_leaf, td)
+        compiled_tree_map(_float_leaf, td)
+
+        # Each unique callable causes a recompilation of the _tree_map frame
+        assert counter.frame_count == 3
+
+    def test_apply_recompiles_with_different_callables(self):
+        """apply() called from a compiled wrapper with different callables
+        causes recompilation — expected Dynamo behavior."""
+        torch._dynamo.reset()
+        td = _get_td()
+
+        def use_apply(td, fn):
+            return td.apply(fn)
+
+        counter = CompileCounter()
+        compiled = torch.compile(use_apply, backend=counter, fullgraph=True)
+
+        compiled(td, _abs_leaf)
+        compiled(td, _neg_leaf)
+        compiled(td, _sqrt_leaf)
+
+        assert counter.frame_count == 3
+
+    def test_callable_fanout_hits_recompile_limit(self):
+        """With strict limits, many different callables exhaust the recompile budget.
+
+        This documents the expected failure mode. Users who need many different
+        callables should either:
+        - Increase recompile_limit/cache_size_limit
+        - Use apply() in eager mode outside the compiled region
+        - Compose operations using built-in methods instead of apply()
+        """
+        torch._dynamo.reset()
+        td = _get_td()
+
+        compiled_tree_map = torch.compile(TensorDict._tree_map, fullgraph=True)
+
+        all_fns = [
+            _clone_leaf, _detach_leaf, _float_leaf, _double_leaf, _half_leaf,
+            _long_leaf, _int_leaf, _abs_leaf, _neg_leaf, _sqrt_leaf,
+        ]
+
+        with torch._dynamo.config.patch(
+            recompile_limit=8,
+            cache_size_limit=8,
+            fail_on_recompile_limit_hit=True,
+        ):
+            with pytest.raises(torch._dynamo.exc.FailOnRecompileLimitHit):
+                for fn in all_fns:
+                    compiled_tree_map(fn, td)
+
+
+@skipif_no_compile
+class TestGetitemCompilation:
+    """Tests for __getitem__ compilation behavior."""
+
+    @pytest.mark.parametrize("key", ["a", "b"])
+    def test_getitem_compiles_and_caches(self, key):
+        """__getitem__ compiles on first call and caches for same key."""
+        torch._dynamo.reset()
+        td = _get_td()
+
+        counter = CompileCounter()
+        compiled_getitem = torch.compile(
+            td.__getitem__, backend=counter, fullgraph=True
+        )
+
+        compiled_getitem(key)
+        assert counter.frame_count == 1
+
+        # Same key, no recompilation
+        compiled_getitem(key)
+        assert counter.frame_count == 1
+
+    def test_getitem_recompiles_for_different_key(self):
+        """__getitem__ with a different key triggers recompilation."""
+        torch._dynamo.reset()
+        td = _get_td()
+
+        counter = CompileCounter()
+        compiled_getitem = torch.compile(
+            td.__getitem__, backend=counter, fullgraph=True
+        )
+
+        compiled_getitem("a")
+        assert counter.frame_count == 1
+
+        compiled_getitem("c")
+        assert counter.frame_count == 2

--- a/tests/test_compile_recompilation.py
+++ b/tests/test_compile_recompilation.py
@@ -1,0 +1,173 @@
+"""Test that TensorContainer operations don't cause _tree_map recompilation.
+
+The bug: ~25 methods each pass a different lambda to the shared _tree_map
+classmethod.  When Dynamo compiles _tree_map as its own frame (which happens
+in complex real-world models but NOT in simple fullgraph=True tests), it guards
+on func.__code__ and recompiles for every unique lambda until the limit (8) is
+exhausted → RecompileError.
+
+The fix: each method calls pytree.tree_map directly when
+torch.compiler.is_compiling(), so _tree_map is never entered during compilation
+and no callable-identity guard accumulates.
+
+Testing strategy:
+    We cannot rely on Dynamo naturally creating a separate frame for _tree_map
+    in simple tests — it always inlines in isolated scenarios.  Instead we
+    verify the fix mechanism with two complementary tests:
+
+    1. Confirm that the underlying Dynamo behavior (recompile on callable
+       identity) still exists by directly compiling _tree_map with >8 callables.
+
+    2. Confirm that each method has the is_compiling() fast path by compiling
+       a function that calls all methods — inside the compiled region,
+       is_compiling() returns True, so methods must bypass _tree_map.  We
+       verify by checking _tree_map is NOT called during compilation (its
+       compile counter stays at 0 frames).
+"""
+
+import pytest
+import torch
+import torch._dynamo
+
+from tensorcontainer.tensor_dict import TensorDict
+from tests.conftest import skipif_no_compile
+
+keys = ["a", "b", "c", "d", "e", "f", "g"]
+
+
+def _get_td():
+    return TensorDict(
+        {k: torch.randn(3, 4, 5) for k in keys},
+        shape=(3, 4),
+    )
+
+
+@skipif_no_compile
+def test_methods_bypass_tree_map_when_compiling():
+    """When compiled, methods must call pytree.tree_map directly instead of
+    _tree_map.  We verify by separately compiling _tree_map and checking its
+    frame count stays at 0 when other methods are called from a compiled region.
+
+    Without the is_compiling() fast paths, _tree_map is called by every method
+    and its frame count would be >= 1.  With the fast paths, _tree_map is
+    bypassed entirely — its frame count stays at 0.
+    """
+    torch._dynamo.reset()
+    td = _get_td()
+
+    # Track whether _tree_map gets compiled as a frame.
+    # We wrap _tree_map with a compile counter backend.
+    tree_map_call_count = 0
+    original_tree_map = TensorDict._tree_map.__func__
+
+    @classmethod
+    def counting_tree_map(cls, func, tree, *rests, is_leaf=None):
+        nonlocal tree_map_call_count
+        tree_map_call_count += 1
+        return original_tree_map(cls, func, tree, *rests, is_leaf=is_leaf)
+
+    def many_ops(td):
+        # 12 distinct operations — each would call _tree_map without the fix
+        x = td.detach()
+        x = x.abs()
+        x = x.float()
+        x = x.clone()
+        x = x.neg()
+        x = x.mul(2.0)
+        x = x.add(1.0)
+        x = x.sub(0.5)
+        x = x.div(2.0)
+        x = x.clamp(-1.0, 1.0)
+        x = x.view(12)
+        x = x.reshape(3, 4)
+        return x
+
+    # Compile and run the function.  Inside the compiled region,
+    # is_compiling() returns True.  Methods with the fast path call
+    # pytree.tree_map directly; methods without it call _tree_map.
+    compiled_fn = torch.compile(many_ops, fullgraph=True)
+
+    # Patch _tree_map to count calls
+    TensorDict._tree_map = counting_tree_map
+    try:
+        tree_map_call_count = 0
+        compiled_fn(td)
+        compiled_call_count = tree_map_call_count
+    finally:
+        TensorDict._tree_map = classmethod(original_tree_map)
+
+    # With the fix: _tree_map should NOT be called during compilation
+    # (is_compiling() fast path bypasses it).
+    # Without the fix: _tree_map would be called 12 times.
+    assert compiled_call_count == 0, (
+        f"_tree_map was called {compiled_call_count} times during compilation. "
+        f"Each method must have an `if torch.compiler.is_compiling(): "
+        f"return pytree.tree_map(...)` fast path to bypass _tree_map."
+    )
+
+
+@skipif_no_compile
+def test_tree_map_directly_compiled_with_many_callables_hits_limit():
+    """Baseline: directly compiling _tree_map and calling it with >8 different
+    callables MUST hit the recompile limit.  This confirms the underlying
+    Dynamo behavior that our fix is designed to avoid.
+
+    If this test starts passing (i.e. Dynamo no longer guards on callable
+    identity), the is_compiling() fast paths become unnecessary — but harmless.
+    """
+    torch._dynamo.reset()
+    td = _get_td()
+
+    compiled_tree_map = torch.compile(TensorDict._tree_map, fullgraph=True)
+
+    callables = [
+        lambda x: x.clone(),
+        lambda x: x.detach(),
+        lambda x: x.float(),
+        lambda x: x.double(),
+        lambda x: x.half(),
+        lambda x: x.long(),
+        lambda x: x.int(),
+        lambda x: x.abs(),
+        lambda x: x.neg(),
+        lambda x: x.sqrt(),
+    ]
+
+    with torch._dynamo.config.patch(
+        recompile_limit=8,
+        cache_size_limit=8,
+        fail_on_recompile_limit_hit=True,
+    ):
+        with pytest.raises(torch._dynamo.exc.FailOnRecompileLimitHit):
+            for fn in callables:
+                compiled_tree_map(fn, td)
+
+
+@skipif_no_compile
+def test_compiled_output_matches_eager():
+    """Compiled output must match eager output for all modified operations."""
+    torch._dynamo.reset()
+
+    def fn(td):
+        x = td.detach()
+        x = x.abs()
+        x = x.float()
+        x = x.clone()
+        x = x.neg()
+        x = x.mul(2.0)
+        x = x.add(1.0)
+        x = x.sub(0.5)
+        x = x.div(2.0)
+        x = x.clamp(-1.0, 1.0)
+        x = x.view(12)
+        x = x.reshape(3, 4)
+        return x
+
+    compiled_fn = torch.compile(fn, fullgraph=True)
+    td = _get_td()
+
+    result = compiled_fn(td)
+    expected = fn(td)
+
+    for key in result.keys():
+        torch.testing.assert_close(result[key], expected[key])


### PR DESCRIPTION
## Summary

This PR includes the commits on `recompiles` that are not yet in `origin/main`, focused on resolving Dynamo recompilation behavior around `_tree_map` and finalizing release metadata.

- Adds compile-mode fast paths that bypass `_tree_map` and use `pytree.tree_map` directly in affected TensorContainer operations, preventing callable-identity guard churn.
- Retains eager-mode `_tree_map` behavior so existing error wrapping and diagnostics remain available outside compiled regions.
- Adds regression coverage for frame-guard/recompilation behavior, including a repro script and compile-specific tests.
- Expands and refines the investigation document in `docs/compile-recompilation-investigation.md` with root cause analysis, alternatives considered, and rationale for the selected fix.
- Bumps project version to `0.9.0` and fixes invalid `pyproject.toml` author metadata.

## Why

Real workloads were hitting `torch._dynamo` recompile limits due to `_tree_map` being compiled as a separate frame with changing callable identities. The compile-path bypass removes this failure mode while preserving eager-path diagnostics and keeping behavior stable.

## Validation

- Added/updated tests covering:
  - `_tree_map` bypass behavior under `torch.compile`
  - frame-guard/recompile-limit repro scenarios
  - compile/eager behavioral consistency for updated call sites
